### PR TITLE
feat: add customizable ace editor themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The _MUSH Portal_ website at <http://www.mushportal.com> connects to _grapenut's
 >   - Terminal font, font size, and word wrapping width.
 >   - Default ANSI background/foreground colors and invert black/white color scheme.
 >   - Command recall size and output history size.
+>   - Toggle local echo for sent commands.
 >   - Sidebar size, position, contents, and navigation compass.
 >   - @decompile/tf multiple attributes directly to the command upload editor.
 >   - Dev console output for debugging user-defined Javascript and MUSH events.

--- a/docs/CLIENT.md
+++ b/docs/CLIENT.md
@@ -708,7 +708,7 @@ Connect to the game server and setup message handlers.
 <a name="Client+sendCommand"></a>
 
 ### client.sendCommand(cmd)
-Send a command string to the server, check macros for a match and append a local echo.
+Send a command string to the server, check macros for a match and append a local echo when enabled.
 
 **Kind**: instance method of [<code>Client</code>](#Client)  
 

--- a/src/ace/theme-mush-dark.js
+++ b/src/ace/theme-mush-dark.js
@@ -1,0 +1,16 @@
+/* global ace */
+ace.define("ace/theme/mush-dark",[
+  "require",
+  "exports",
+  "module",
+  "ace/lib/dom",
+  "ace/theme/tomorrow_night_bright"
+], function(require, exports, module) {
+  const base = require("ace/theme/tomorrow_night_bright");
+  exports.isDark = true;
+  exports.cssClass = "ace-mush-dark";
+  exports.cssText = base.cssText.replace(/ace-tomorrow-night-bright/g, "ace-mush-dark");
+  const dom = require("ace/lib/dom");
+  dom.importCssString(exports.cssText, exports.cssClass);
+});
+

--- a/src/ace/theme-mush-light.js
+++ b/src/ace/theme-mush-light.js
@@ -1,0 +1,16 @@
+/* global ace */
+ace.define("ace/theme/mush-light",[
+  "require",
+  "exports",
+  "module",
+  "ace/lib/dom",
+  "ace/theme/chrome"
+], function(require, exports, module) {
+  const base = require("ace/theme/chrome");
+  exports.isDark = false;
+  exports.cssClass = "ace-mush-light";
+  exports.cssText = base.cssText.replace(/ace-chrome/g, "ace-mush-light");
+  const dom = require("ace/lib/dom");
+  dom.importCssString(exports.cssText, exports.cssClass);
+});
+

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -98,9 +98,12 @@ class Client {
       ansiFG: 'ansi-37',
       ansiBG: 'ansi-40',
       invertHighlight: false,
+      // code editor theme
+      darkTheme: true,
       // terminal settings
       terminalWidth: 100,
       terminalAutoScroll: true,
+      showLocalEcho: true,
       // upload editor
       decompileEditor: true,
       decompileKey: 'FugueEdit > ',
@@ -205,6 +208,7 @@ class Client {
       upload: null,
       backup: null,
       configure: null,
+      formEditor: null,
       spawns: [],
     };
     
@@ -639,6 +643,11 @@ class Client {
       this.output.calcDimensions();
       //this.sendText("SCREENWIDTH " + this.settings.terminalWidth);
       //this.sendText("SCREENHEIGHT " + Math.floor(this.output.root.parentNode.clientHeight / this.output.dims.height));
+    } else if (key === 'darkTheme') {
+      const theme = `ace/theme/${this.settings.darkTheme ? 'mush-dark' : 'mush-light'}`;
+      this.react.upload && this.react.upload.editor.current.editor.setTheme(theme);
+      this.react.backup && this.react.backup.editor.current.editor.setTheme(theme);
+      this.react.formEditor && this.react.formEditor.editor.current.editor.setTheme(theme);
     } else if (key === 'timersEnabled') {
       if (this.settings[key]) {
         this.startTimers();
@@ -1435,7 +1444,9 @@ class Client {
 
     cmd = this.filterUnicode(cmd);
     this.sendMacro(cmd);
-    this.scrollIfNeeded(() => this.appendMessage('localEcho', cmd));
+    if (this.settings.showLocalEcho) {
+      this.scrollIfNeeded(() => this.appendMessage('localEcho', cmd));
+    }
     this.saveRecallHistory();
   }
   

--- a/src/modules/Backup/index.jsx
+++ b/src/modules/Backup/index.jsx
@@ -13,7 +13,8 @@ import UndoIcon from '@material-ui/icons/Undo';
 
 import AceEditor from 'react-ace';
 import 'brace/mode/json';
-import 'brace/theme/tomorrow_night_bright';
+import '../../ace/theme-mush-dark';
+import '../../ace/theme-mush-light';
 
 //////////////////////////////////////////////////////////////////////
 
@@ -119,7 +120,7 @@ class Backup extends React.Component {
           ref={this.editor}
           mode="mushcode"
           width="100%"
-          theme="tomorrow_night_bright"
+          theme={window.client.settings.darkTheme ? 'mush-dark' : 'mush-light'}
           value={text}
           onChange={this.changeText}
           wrapEnabled={!window.client.mobile}

--- a/src/modules/Configure/FormEditor.jsx
+++ b/src/modules/Configure/FormEditor.jsx
@@ -19,7 +19,8 @@ import AceEditor from 'react-ace';
 import 'brace/mode/mushcode';
 import 'brace/mode/javascript';
 import 'brace/mode/css';
-import 'brace/theme/tomorrow_night_bright';
+import '../../ace/theme-mush-dark';
+import '../../ace/theme-mush-light';
 
 
 //////////////////////////////////////////////////////////////////////
@@ -154,11 +155,13 @@ class FormEditor extends React.Component {
     const { panel } = this.props;
     panel.options.resizeit.resize = this.onResize;
     window.client.panels.resizeit(panel, panel.options.resizeit);
+    window.client.react.formEditor = this;
   }
-  
+
   componentWillUnmount() {
     this.props.panel.options.resizeit.resize = null;
     clearTimeout(this.clearStatus);
+    window.client.react.formEditor = null;
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -436,7 +439,7 @@ class FormEditor extends React.Component {
                 className={classes.editor}
                 ref={this.editor}
                 mode={mode ? rtype.toLowerCase() : ltype.toLowerCase()}
-                theme="tomorrow_night_bright"
+                theme={window.client.settings.darkTheme ? 'mush-dark' : 'mush-light'}
                 value={item.text}
                 onChange={this.changeText}
                 wrapEnabled={!window.client.mobile}

--- a/src/modules/Settings/index.jsx
+++ b/src/modules/Settings/index.jsx
@@ -194,7 +194,9 @@ class Settings extends React.Component {
       historySize, historySpawnSize, mobileHideTaskbar, mobileHideStatusbar, allowServerChange, activityDelay,
       sidebarOpen, sidebarAnchor, sidebarAlwaysShow, sidebarShowPlayers, fontFamily, fontSize, activityReposition,
       recallButtons, recallAnchor, recallSize, mobileFontSize, terminalWidth, timersAutoStart, activityEnabled,
-      sidebarShowThings, sidebarShowExits, sidebarShowCompass, sidebarDense, timersEnabled, terminalAutoScroll } = this.state;
+      sidebarShowThings, sidebarShowExits, sidebarShowCompass, sidebarDense,
+      timersEnabled, terminalAutoScroll, showLocalEcho, darkTheme
+    } = this.state;
     const isMobile = window.client.mobile;
    
     var debugging = (
@@ -319,9 +321,33 @@ class Settings extends React.Component {
             <Switch checked={terminalAutoScroll} value="terminalAutoScroll" onChange={this.handleSwitch('terminalAutoScroll')} />
           </ListItemSecondaryAction>
         </ListItem>
+
+        <ListItem dense>
+          <ListItemIcon>
+            <ShortTextIcon />
+          </ListItemIcon>
+          <ListItemText className={classes.switchText} primary="Show commands in output?" />
+          <ListItemSecondaryAction>
+            <Switch checked={showLocalEcho} value="showLocalEcho" onChange={this.handleSwitch('showLocalEcho')} />
+          </ListItemSecondaryAction>
+        </ListItem>
       </List>
     );
         
+    var editorTheme = (
+      <List className={classes.list} disablePadding dense>
+        <ListItem dense>
+          <ListItemIcon>
+            <CodeIcon />
+          </ListItemIcon>
+          <ListItemText className={classes.switchText} primary="Use dark code editor theme?" />
+          <ListItemSecondaryAction>
+            <Switch checked={darkTheme} value="darkTheme" onChange={this.handleSwitch('darkTheme')} />
+          </ListItemSecondaryAction>
+        </ListItem>
+      </List>
+    );
+
     var font = (
       <List className={classes.list} disablePadding dense>
         <ListItem dense>
@@ -659,6 +685,15 @@ class Settings extends React.Component {
                 </ExpansionPanelSummary>
                 <ExpansionPanelDetails classes={{ root: classes.noPadding }}>
                   {color}
+                </ExpansionPanelDetails>
+              </ExpansionPanel>
+
+              <ExpansionPanel className={classes.panel} expanded={expandAll || expanded === 'editorTheme'} onChange={this.handleExpand('editorTheme')}>
+                <ExpansionPanelSummary classes={{ root: classes.noPadding }} expandIcon={<ExpandMoreIcon />}>
+                  <Typography className={classes.summaryText}>Code Editor Theme</Typography>
+                </ExpansionPanelSummary>
+                <ExpansionPanelDetails classes={{ root: classes.noPadding }}>
+                  {editorTheme}
                 </ExpansionPanelDetails>
               </ExpansionPanel>
 

--- a/src/modules/Upload/index.jsx
+++ b/src/modules/Upload/index.jsx
@@ -13,7 +13,8 @@ import UndoIcon from '@material-ui/icons/Redo';
 
 import AceEditor from 'react-ace';
 import 'brace/mode/mushcode';
-import 'brace/theme/tomorrow_night_bright';
+import '../../ace/theme-mush-dark';
+import '../../ace/theme-mush-light';
 
 //////////////////////////////////////////////////////////////////////
 
@@ -173,7 +174,7 @@ class Upload extends React.Component {
           ref={this.editor}
           mode="mushcode"
           width="100%"
-          theme="tomorrow_night_bright"
+          theme={window.client.settings.darkTheme ? 'mush-dark' : 'mush-light'}
           value={text}
           onChange={this.changeText}
           readOnly={uploading}


### PR DESCRIPTION
## Summary
- create custom dark and light Ace editor themes
- allow users to toggle editor theme and local echo in settings
- load Ace editor theme dynamically based on user preference
- fix build issues by declaring global `ace` in custom themes
- propagate theme changes to open editors when toggling dark mode

## Testing
- `npm test -- --watchAll=false`
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb06221ad88325b101dc5c1e7c7fc3